### PR TITLE
Manutenção validação BibtexKey

### DIFF
--- a/src/main/java/org/jabref/logic/integrity/ValidBibtexKeyChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/ValidBibtexKeyChecker.java
@@ -23,6 +23,15 @@ public class ValidBibtexKeyChecker implements ValueChecker {
             return Optional.of(Localization.lang("empty BibTeX key"));
         }
 
+        if (value.length()<2) {
+            return Optional.of(Localization.lang("BibTeX key to small"));
+        }
+
+
+        if (!Character.isLetter(value.charAt(0))) {
+            return Optional.of(Localization.lang("BibteX invalid (first char is not a letter)"));
+        }
+
         String cleaned = BibtexKeyGenerator.cleanKey(value, enforceLegalKey);
 
         if (cleaned.equals(value)) {


### PR DESCRIPTION
- Inserção de verificação de tamanho da BibtexKey  (necessário ser maior que 2) e verificação do primeiro caractere da chave que deverá ser uma letra.

Closes #4