### PR TITLE
criacao do botao para inserir uma nova biblioteca

### DIFF
--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -89,7 +89,18 @@ public class ImportEntriesViewModel extends AbstractViewModel {
                     if (!continueImport) {
                         dialogService.notify(Localization.lang("Import canceled"));
                     } else {
-                        buildImportHandlerThenImportEntries(entriesToImport);
+                        boolean continuecreate = dialogService.showConfirmationDialogWithOptOutAndWait(Localization.lang("Duplicates found"),
+                                Localization.lang("To solve this problem you can choose create a new entry or import into current library"),
+                                Localization.lang("Create new file"),
+                                Localization.lang("Import into library"),
+                                Localization.lang("Disable this confirmation dialog"),
+                                optOut -> preferences.setShouldWarnAboutDuplicatesForImport(!optOut));
+                        if(!continuecreate){
+                            buildImportHandlerThenImportEntries(entriesToImport);
+                        }else{
+                            /**create new option**/
+                        }
+
                     }
                 } else {
                     buildImportHandlerThenImportEntries(entriesToImport);


### PR DESCRIPTION
-Cria o botão de opção para poder criar um novo arquivo de referências ou incluir referências na atual, em caso de conflito de itens na biblioteca usada com a que deseja importar.

*Falta implementar a função do botão.